### PR TITLE
Remove storing anything on session, add admin settings notes for login

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,21 @@ This is a [Discourse](http://www.discourse.org/) plugin for authenticating with 
 - Rebuild container
 - Test!
 
-
 ## Install and setup this plugin
 - Install this repository as a Discourse plugin ([instructions](https://meta.discourse.org/t/install-a-plugin/19157))
 - Rebuild container
 - Test!
 - (You should see a 'Login with EdX' button on the Login page, but it won't work yet)
+
+##### Discourse login setup
+- The intent is that the site is private, and learners can only gain access by signing in through EdX and launching the site through LTI.
+- Admin users sign into Discourse directly.
+- In the Discourse Admin UI, set:
+  - `invite only`: true
+  - `login required`: true
+  - `must approve users`: false (default)
+  - `enable local logins`: true (default)
+  - `allow new registrations`: true (default)
 
 ##### Discourse plugin setup
 - Pick an id for the forum site, generate a consumer key and secret

--- a/lti_strategy.rb
+++ b/lti_strategy.rb
@@ -10,9 +10,6 @@ module OmniAuth
     class Lti
       include OmniAuth::Strategy
 
-      # For storing session
-      option :rails_session_key, 'omniauth_lti_provider_rails_session_key'
-      
       # These are the params that the LTI Tool Provider receives
       # in the LTI handoff.  The values here are set in `callback_phase`.
       uid { @lti_provider.user_id }
@@ -34,9 +31,6 @@ module OmniAuth
         begin
           log :info, 'callback_phase: start'
           @lti_provider = create_valid_lti_provider!(request)
-          session[options.rails_session_key] = @lti_provider.to_params
-
-          log :info, 'callback_phase: set session var'
           super
         rescue ::ActionController::BadRequest
           return [400, {}, ['400 Bad Request']]


### PR DESCRIPTION
Storing session data isn't needed, and was leftover from earlier attempts.

Login settings are in the README now.
![screen shot 2017-02-01 at 2 37 12 pm](https://cloud.githubusercontent.com/assets/1056957/22523036/ef639448-e88b-11e6-8b60-3ad73990b361.png)
