### PR TITLE
Fix bug with mixed-case email addresses

### DIFF
--- a/lti_authenticator.rb
+++ b/lti_authenticator.rb
@@ -38,7 +38,7 @@ class LTIAuthenticator < ::Auth::Authenticator
 
     # Lookup or create a new User record.
     user = User.find_or_initialize_by({
-      email: auth_result.email,
+      email: auth_result.email.downcase,
       username: auth_result.username
     })
     if user.new_record?


### PR DESCRIPTION
This fixes a login bug that would affect users with mixed-cased emails in EdX.  On their second LTI attempt, the lookup for their user would fail (since Discourse downcases the email), but then creating a new user would fail the uniqueness validation since that comparison is case-insensitive.

This scrubs the case from whatever EdX provides.