### PR TITLE
Remove password_required!

### DIFF
--- a/lti_authenticator.rb
+++ b/lti_authenticator.rb
@@ -48,7 +48,6 @@ class LTIAuthenticator < ::Auth::Authenticator
       user.staged = false
       user.active = true
       user.password = SecureRandom.hex(32)
-      user.password_required!
       user.save!
       user.reload
     end

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------------
 # name:  discourse-edx-lti
 # about: Discourse plugin to authenticate with LTI (eg., for an EdX course)
-# version: 0.4.0
+# version: 0.5.0
 # author: MIT Teaching Systems Lab
 # url: https://github.com/mit-teaching-systems-lab/discourse-edx-lti
 # required_version: 1.8.0.beta4


### PR DESCRIPTION
From reading through the source more, and doing some console debugging, this doesn't work the way I thought.  Setting this value is an instance variable.  So the first time through the LTI process, the call to `reload` loses this value, and the validation triggered up the call stack in `omniauth_callbacks_controller#115` fails.  On the second time through, this succeeds because that method isn't called on the user load path.

It's unclear what the user impact here is, since this hasn't come up in any of our manual testing, we haven't had widescale reports of any problems, but the Discourse logging shows this error has affected most users.

