### PR TITLE
Fix username limit bug, remove password_required!

### DIFF
--- a/lti_authenticator.rb
+++ b/lti_authenticator.rb
@@ -1,7 +1,7 @@
 # Discourse Authenticator class
 class LTIAuthenticator < ::Auth::Authenticator  
   DISCOURSE_USERNAME_MAX_LENGTH = 20
-  
+
   # override hook
   def name
     'lti'
@@ -49,7 +49,6 @@ class LTIAuthenticator < ::Auth::Authenticator
       user.staged = false
       user.active = true
       user.password = SecureRandom.hex(32)
-      user.password_required!
       user.save!
       user.reload
     end

--- a/lti_authenticator.rb
+++ b/lti_authenticator.rb
@@ -1,5 +1,7 @@
 # Discourse Authenticator class
 class LTIAuthenticator < ::Auth::Authenticator  
+  DISCOURSE_USERNAME_MAX_LENGTH = 20
+  
   # override hook
   def name
     'lti'
@@ -28,7 +30,6 @@ class LTIAuthenticator < ::Auth::Authenticator
 
     # Grab the info we need from OmniAuth
     # Discourse has a limit of 20 characters for usernames, but EdX does not.
-    DISCOURSE_USERNAME_MAX_LENGTH = 20
     omniauth_params = auth_token[:info]
     auth_result.username = omniauth_params[:edx_username].slice(0, DISCOURSE_USERNAME_MAX_LENGTH)
     auth_result.name = omniauth_params[:edx_username]

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------------
 # name:  discourse-edx-lti
 # about: Discourse plugin to authenticate with LTI (eg., for an EdX course)
-# version: 0.4.1
+# version: 0.5.1
 # author: MIT Teaching Systems Lab
 # url: https://github.com/mit-teaching-systems-lab/discourse-edx-lti
 # required_version: 1.8.0.beta4

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------------
 # name:  discourse-edx-lti
 # about: Discourse plugin to authenticate with LTI (eg., for an EdX course)
-# version: 0.4.0
+# version: 0.4.1
 # author: MIT Teaching Systems Lab
 # url: https://github.com/mit-teaching-systems-lab/discourse-edx-lti
 # required_version: 1.8.0.beta4


### PR DESCRIPTION
From reading through the source more, and doing some console debugging, this doesn't work the way I thought.  Setting this value is an instance variable.  So the first time through the LTI process, the call to `reload` loses this value, and the validation triggered up the call stack in `omniauth_callbacks_controller#115` fails.  On the second time through, this succeeds because that method isn't called on the user load path.

It's unclear what the user impact here is, since this hasn't come up in any of our manual testing, we haven't had widescale reports of any problems, but the Discourse logging shows this error has affected most users.

Also fix syntax error that wasn't deployed... :|  Tested locally.