### PR TITLE
More logging of errors for LTI exceptions

### DIFF
--- a/lti_strategy.rb
+++ b/lti_strategy.rb
@@ -35,23 +35,23 @@ module OmniAuth
           log :info, "lti_provider.custom_params: #{@lti_provider.custom_params.inspect}"
           set_origin_url!(@lti_provider.custom_params)
           super
-        rescue ::ActionController::BadRequest
-          log :info, "lti_provider.bad_request, params: #{request.params.inspect}"
+        rescue ::ActionController::BadRequest => err
+          log :info, "lti_provider.bad_request, params: #{request.params.inspect}, err: #{err.inspect}"
           return [400, {}, ['400 Bad Request']]
-        rescue ::Timeout::Error
-          log :info, "lti_provider.Timeout::Error, params: #{request.params.inspect}"
+        rescue ::Timeout::Error => err
+          log :info, "lti_provider.Timeout::Error, params: #{request.params.inspect}, err: #{err.inspect}"
           fail!(:timeout)
-        rescue ::Net::HTTPFatalError, ::OpenSSL::SSL::SSLError
-          log :info, "lti_provider.Net::HTTPFatalError, params: #{request.params.inspect}"
+        rescue ::Net::HTTPFatalError, ::OpenSSL::SSL::SSLError => err
+          log :info, "lti_provider.Net::HTTPFatalError, params: #{request.params.inspect}, err: #{err.inspect}"
           fail!(:service_unavailable)
-        rescue ::OAuth::Unauthorized
-          log :info, "lti_provider.OAuth::Unauthorized, params: #{request.params.inspect}"
+        rescue ::OAuth::Unauthorized => err
+          log :info, "lti_provider.OAuth::Unauthorized, params: #{request.params.inspect}, err: #{err.inspect}"
           fail!(:invalid_credentials)
-        rescue ::OmniAuth::NoSessionError
-          log :info, "lti_provider.OmniAuth::NoSessionError, params: #{request.params.inspect}"
+        rescue ::OmniAuth::NoSessionError => err
+          log :info, "lti_provider.OmniAuth::NoSessionError, params: #{request.params.inspect}, err: #{err.inspect}"
           fail!(:session_expired)
-        rescue ::ActiveRecord::RecordInvalid
-          log :info, "lti_provider.ActiveRecord::RecordInvalid, params: #{request.params.inspect}"
+        rescue ::ActiveRecord::RecordInvalid => err
+          log :info, "lti_provider.ActiveRecord::RecordInvalid, params: #{request.params.inspect}, err: #{err.inspect}"
           fail!(:record_invalid)
         end
       end

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------------
 # name:  discourse-edx-lti
 # about: Discourse plugin to authenticate with LTI (eg., for an EdX course)
-# version: 0.5.1
+# version: 0.5.2
 # author: MIT Teaching Systems Lab
 # url: https://github.com/mit-teaching-systems-lab/discourse-edx-lti
 # required_version: 1.8.0.beta4


### PR DESCRIPTION
This isn't capturing what's going on with an invalid record at the moment, so add more logging.