### PR TITLE
Update user lookup to match code in 1.9.0 related to multiple email a…

### DIFF
--- a/lti_authenticator.rb
+++ b/lti_authenticator.rb
@@ -39,18 +39,30 @@ class LTIAuthenticator < ::Auth::Authenticator
     auth_result.extra_data = omniauth_params.merge(lti_uid: lti_uid)
     log :info, "after_authenticate, auth_result: #{auth_result.inspect}"
 
-    # Lookup or create a new User record.
-    user = User.find_or_initialize_by({
-      email: auth_result.email.downcase,
-      username: auth_result.username
-    })
-    if user.new_record?
-      log :info, "after_authenticate, first-time user, saving..."
+    # Lookup or create a new User record, requiring that both email and username match.
+    # Discourse's User model patches some Rails methods, so we use their
+    # methods here rather than reaching into details of how these fields are stored in the DB.
+    # This appears related to changes in https://github.com/discourse/discourse/pull/4977
+    user_by_email = User.find_by_email(auth_result.email.downcase)
+    user_by_username = User.find_by_username(auth_result.username)
+    both_matches_found = user_by_email.present? && user_by_username.present?
+    no_matches_found = user_by_email.nil? && user_by_username.nil?
+    if both_matches_found && user_by_email.id == user_by_username.id
+      log :info, "after_authenticate, found user records by both username and email and they matched, using existing user..."
+      user = user_by_email
+    elsif no_matches_found
+      log :info, "after_authenticate, no matches found for email or username, creating user record for first-time user..."
+      user = User.new(email: auth_result.email.downcase, username: auth_result.username)
       user.staged = false
       user.active = true
       user.password = SecureRandom.hex(32)
       user.save!
       user.reload
+    else
+      log :info, "after_authenticate, found user records that did not match by username and email"
+      log :info, "after_authenticate, user_by_email: #{user_by_email.inspect}"
+      log :info, "after_authenticate, user_by_username: #{user_by_username.inspect}"
+      raise ::ActiveRecord::RecordInvalid('LTIAuthenticator: edge case for finding User records where username and email did not match, aborting...')
     end
 
     # Return a reference to the User record.

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,10 +1,10 @@
 # ---------------------------------------------------------------
 # name:  discourse-edx-lti
 # about: Discourse plugin to authenticate with LTI (eg., for an EdX course)
-# version: 0.5.2
+# version: 0.6.1
 # author: MIT Teaching Systems Lab
 # url: https://github.com/mit-teaching-systems-lab/discourse-edx-lti
-# required_version: 1.8.0.beta4
+# required_version: 1.9.0.beta8
 # ---------------------------------------------------------------
 
 # Plugins need to explicitly include their dependencies, and the loading


### PR DESCRIPTION
This leads to the LTI user lookup always failing (which is what should happen for the initial LTI login, but not for subsequent logins).  The error in Discourse looks like this to users:
<img width="572" alt="screen shot 2017-09-06 at 11 41 15 am" src="https://user-images.githubusercontent.com/1056957/30120962-4ffc2fc4-92f8-11e7-97a6-224697d45e04.png">

And stack trace pinpointing that this is coming from the call to `User.find_or_initialize_by`looks like:
```
var/www/discourse/vendor/bundle/ruby/2.3.0/gems/logster-1.2.7/lib/logster/logger.rb:93:in `add_with_opts'
/var/www/discourse/vendor/bundle/ruby/2.3.0/gems/logster-1.2.7/lib/logster/logger.rb:50:in `add'
/usr/local/lib/ruby/2.3.0/logger.rb:507:in `error'
/var/www/discourse/plugins/discourse-edx-lti/lti_strategy.rb:61:in `log'
/var/www/discourse/vendor/bundle/ruby/2.3.0/gems/omniauth-1.6.1/lib/omniauth/strategy.rb:475:in `fail!'
/var/www/discourse/plugins/discourse-edx-lti/lti_strategy.rb:55:in `rescue in callback_phase'
/var/www/discourse/plugins/discourse-edx-lti/lti_strategy.rb:31:in `callback_phase'
/var/www/discourse/vendor/bundle/ruby/2.3.0/gems/omniauth-1.6.1/lib/omniauth/strategy.rb:230:in `callback_call'
```

Tracking this to the Discourse `User` model, it seems the changes to support multiple emails mean that past code using Rails find methods to look for email won't work anymore.  From looking at git blame, this appears related to changes in https://github.com/discourse/discourse/pull/4977 to enable multiple email addresses.

This PR works around by using the monkey-patched find methods on `User` related to email and username lookups, and then manually checks that both find the same record.