### PR TITLE
Fix to skip_before_action

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------------
 # name:  discourse-edx-lti
 # about: Discourse plugin to authenticate with LTI (eg., for an EdX course)
-# version: 0.6.1
+# version: 0.7.0
 # author: MIT Teaching Systems Lab
 # url: https://github.com/mit-teaching-systems-lab/discourse-edx-lti
 # required_version: 1.9.0.beta8
@@ -87,7 +87,7 @@ after_initialize do
     requires_plugin PLUGIN_NAME
 
     # Adapted from Discourse's StaticController#enter
-    skip_before_filter :check_xhr, :redirect_to_login_if_required, :verify_authenticity_token
+    skip_before_action :check_xhr, :redirect_to_login_if_required, :verify_authenticity_token
 
     def redirect_to_consumer
       url = SiteSetting.lti_consumer_authenticate_url


### PR DESCRIPTION
Fixing this when upgrading:
```
$ bundle exec rake multisite:migrate
rake aborted!
NoMethodError: undefined method `skip_before_filter' for DiscourseEdxLti::LtiController:Class
Did you mean?  skip_before_action
/var/www/discourse/plugins/discourse-edx-lti/plugin.rb:90:in `<class:LtiController>'
/var/www/discourse/plugins/discourse-edx-lti/plugin.rb:86:in `block in activate!'
/var/www/discourse/lib/plugin/instance.rb:254:in `block in notify_after_initialize'
/var/www/discourse/lib/plugin/instance.rb:252:in `each'
/var/www/discourse/lib/plugin/instance.rb:252:in `notify_after_initialize'
/var/www/discourse/config/application.rb:211:in `each'
/var/www/discourse/config/application.rb:211:in `block in <class:Application>'
/var/www/discourse/vendor/bundle/ruby/2.3.0/gems/activesupport-5.1.3/lib/active_support/lazy_load_hooks.rb:43:in `execute_hook'
/var/www/discourse/vendor/bundle/ruby/2.3.0/gems/activesupport-5.1.3/lib/active_support/lazy_load_hooks.rb:52:in `block in run_load_hooks'
/var/www/discourse/vendor/bundle/ruby/2.3.0/gems/activesupport-5.1.3/lib/active_support/lazy_load_hooks.rb:51:in `each'
/var/www/discourse/vendor/bundle/ruby/2.3.0/gems/activesupport-5.1.3/lib/active_support/lazy_load_hooks.rb:51:in `run_load_hooks'
/var/www/discourse/vendor/bundle/ruby/2.3.0/gems/railties-5.1.3/lib/rails/application/finisher.rb:73:in `block in <module:Finisher>'
/var/www/discourse/vendor/bundle/ruby/2.3.0/gems/railties-5.1.3/lib/rails/initializable.rb:30:in `instance_exec'
/var/www/discourse/vendor/bundle/ruby/2.3.0/gems/railties-5.1.3/lib/rails/initializable.rb:30:in `run'
/var/www/discourse/vendor/bundle/ruby/2.3.0/gems/railties-5.1.3/lib/rails/initializable.rb:59:in `block in run_initializers'
/var/www/discourse/vendor/bundle/ruby/2.3.0/gems/railties-5.1.3/lib/rails/initializable.rb:58:in `run_initializers'
/var/www/discourse/vendor/bundle/ruby/2.3.0/gems/railties-5.1.3/lib/rails/application.rb:353:in `initialize!'
/var/www/discourse/vendor/bundle/ruby/2.3.0/gems/railties-5.1.3/lib/rails/railtie.rb:185:in `public_send'
/var/www/discourse/vendor/bundle/ruby/2.3.0/gems/railties-5.1.3/lib/rails/railtie.rb:185:in `method_missing'
/var/www/discourse/config/environment.rb:5:in `<top (required)>'
/var/www/discourse/vendor/bundle/ruby/2.3.0/gems/activesupport-5.1.3/lib/active_support/dependencies.rb:292:in `require'
/var/www/discourse/vendor/bundle/ruby/2.3.0/gems/activesupport-5.1.3/lib/active_support/dependencies.rb:292:in `block in require'
/var/www/discourse/vendor/bundle/ruby/2.3.0/gems/activesupport-5.1.3/lib/active_support/dependencies.rb:258:in `load_dependency'
/var/www/discourse/vendor/bundle/ruby/2.3.0/gems/activesupport-5.1.3/lib/active_support/dependencies.rb:292:in `require'
/var/www/discourse/vendor/bundle/ruby/2.3.0/gems/railties-5.1.3/lib/rails/application.rb:329:in `require_environment!'
/var/www/discourse/vendor/bundle/ruby/2.3.0/gems/railties-5.1.3/lib/rails/application.rb:445:in `block in run_tasks_blocks'
/var/www/discourse/vendor/bundle/ruby/2.3.0/gems/rake-12.0.0/exe/rake:27:in `<top (required)>'
/usr/local/bin/bundle:22:in `load'
/usr/local/bin/bundle:22:in `<main>'
Tasks: TOP => multisite:migrate => environment
(See full trace by running task with --trace)
```