### PR TITLE
Work around EdX usernames that would be invalid in Discourse

### DIFF
--- a/lti_authenticator.rb
+++ b/lti_authenticator.rb
@@ -31,7 +31,7 @@ class LTIAuthenticator < ::Auth::Authenticator
     # Grab the info we need from OmniAuth
     # Discourse has a limit of 20 characters for usernames, but EdX does not.
     omniauth_params = auth_token[:info]
-    auth_result.username = omniauth_params[:edx_username].slice(0, DISCOURSE_USERNAME_MAX_LENGTH)
+    auth_result.username = build_discourse_username omniauth_params[:edx_username]
     auth_result.name = omniauth_params[:edx_username]
     auth_result.email = omniauth_params[:email]
     auth_result.email_valid = auth_result.email.present?
@@ -81,5 +81,12 @@ class LTIAuthenticator < ::Auth::Authenticator
   protected
   def log(method_symbol, text)
     Rails.logger.send(method_symbol, "LTIAuthenticator: #{text}")
+  end
+
+  # Discourse has a limit of 20 characters for usernames, but EdX does not, so we slice it.
+  # Edx username can still be (or become) invalid after the slicing.
+  # E.g. it can end on special symbol(.-_) or contain more than 1 underscore in a row
+  def build_discourse_username(edx_username)
+    edx_username.slice(0, DISCOURSE_USERNAME_MAX_LENGTH).gsub("__","_").chomp("_")
   end
 end


### PR DESCRIPTION
Adding on some comments to @zimka's awesome pull request here: https://github.com/mit-teaching-systems-lab/discourse-edx-lti/pull/24.