### PR TITLE
Ship login settings with plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,19 +46,12 @@ Note that this may be handled differently on edX versus an Open edX instance.  S
 
 ## Setup
 #### Initial setup for new course forums
-- Follow [Install Discourse in under 30 minutes](https://blog.discourse.org/2014/04/install-discourse-in-under-30-minutes/) (or deploy on your own setup)
-- Follow the Discourse instructions to setup SSL with Let's Encrypt ([instructions](https://meta.discourse.org/t/setting-up-lets-encrypt/40709))
-- Setup [MailGun](https://www.mailgun.com/) or another email provider
-- Add DNS records for email and for your new Discourse instance
-- Wait to setup additional [features](https://github.com/discourse/discourse/blob/master/docs/INSTALL-cloud.md#add-more-discourse-features) until after the plugin and EdX setup is done.
-- When the site is up, set it as "private" login and don't invite any users yet
-- Test!
+- This repository assumes you've already done this.  See [mit-teaching-systems-lab/discourse-for-moocsters](https://github.com/mit-teaching-systems-lab/discourse-for-moocsters) for setup instructions for how we do this in our labs at MIT.
 
 #### Install and setup this plugin
 - Install this repository as a Discourse plugin ([instructions](https://meta.discourse.org/t/install-a-plugin/19157))
 - Rebuild container
-- Test!
-- (You should see a 'Login with EdX' button on the Login page, but it won't work yet)
+- Test!  Logout from your admin user, and click the Login button.  You should see a `Login with EdX` button at the top of the Login dialog box (which won't work yet).
 
 ###### Discourse login setup
 - The intent is that the site is private, and learners can only gain access by signing in through EdX and launching the site through LTI.

--- a/README.md
+++ b/README.md
@@ -54,15 +54,8 @@ Note that this may be handled differently on edX versus an Open edX instance.  S
 - Test!  Logout from your admin user, and click the Login button.  You should see a `Login with EdX` button at the top of the Login dialog box (which won't work yet).
 
 ###### Discourse login setup
-- The intent is that the site is private, and learners can only gain access by signing in through EdX and launching the site through LTI.
-- Admin users sign into Discourse directly.
-- In the Discourse Admin UI, within the `Basic Setup` and `Users` sections, set:
-  - `invite only`: true
-  - `login required`: true
-  - `must approve users`: false (default)
-  - `enable local logins`: true (default)
-  - `allow new registrations`: true (default)
-  - `email editable`: false
+- The intent is that the site is private, and learners can only gain access by signing in through EdX and launching the site through LTI.  Admin users sign into Discourse directly.
+- This plugin will also set some admin site settings, which you can see in [config/settings.yml](config/settings.yml).  You can edit these in the Discourse Admin UI, but note that the interactions between these settings in different parts of the product are complex, and we don't recommend changing these defaults for a private course.
 
 ###### Discourse plugin setup
 - Pick an id for the forum site, generate a consumer key and secret

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -8,3 +8,13 @@ plugins:
   lti_consumer_authenticate_url:
     default: 'https://edx.org/foo'
     client: true
+
+login:
+  invite_only: true
+  login_required: true
+  must_approve_users: false
+  enable_local_logins: true
+  allow_new_registrations: true
+
+users:
+  email_editable: false

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------------
 # name:  discourse-edx-lti
 # about: Discourse plugin to authenticate with LTI (eg., for an EdX course)
-# version: 0.7.0
+# version: 0.8.0
 # author: MIT Teaching Systems Lab
 # url: https://github.com/mit-teaching-systems-lab/discourse-edx-lti
 # required_version: 1.9.0.beta8


### PR DESCRIPTION
These are in the docs, let's move them into code.  Also clarify setup and link back to https://github.com/mit-teaching-systems-lab/discourse-for-moocsters.